### PR TITLE
Setup automated "go build" Github Action.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+name: Create release
+on:
+  push:
+    tags:
+    - 'v*'
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-20.04
+    steps:
+
+      - name: Set release version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16.3'
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build project
+        run: ./build.sh
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            runplugin
+            runplugin-arm64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+GOOS=linux GOARCH=amd64 go build -o ./runplugin ./cmd/runplugin 
+GOOS=linux GOARCH=arm64 go build -o ./runplugin-arm64 ./cmd/runplugin

--- a/cmd/runplugin/main.go
+++ b/cmd/runplugin/main.go
@@ -64,8 +64,13 @@ func main() {
 		log.Fatal(err)
 	}
 
+	sch := &runplugin.Scheduler{
+		KubernetesClientset: clientset,
+		RabbitMQClient:      rmqclient,
+	}
+
 	args := flag.Args()
-	if err := runplugin.RunPlugin(clientset, rmqclient, args[0], args[1:]...); err != nil {
+	if err := sch.RunPlugin(args[0], args[1:]...); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
As part of [Sage-817], I wanted to start using the SES runplugin command Yongho and I worked on to deploy plugins.

To encourage that transition, I set up an action which automatically creates a release with the multi-arch go build executables as assets. All you have to do is tag a commit with `v*.*.*`.