### PR TITLE
[SAGE-817] Fixed plugin username

### DIFF
--- a/pkg/runplugin/runplugin.go
+++ b/pkg/runplugin/runplugin.go
@@ -33,9 +33,10 @@ func (sch *Scheduler) RunPlugin(image string, args ...string) error {
 	}
 
 	config := &pluginConfig{
-		Image:    image,
-		Name:     parts[0],
-		Version:  parts[1],
+		Image:   image,
+		Name:    parts[0],
+		Version: parts[1],
+		// NOTE(sean) username will be validated by wes-data-sharing-service. see: https://github.com/waggle-sensor/wes-data-sharing-service/blob/0e5a44b1ce6e6109a660b2922f56523099054750/main.py#L34
 		Username: "plugin." + base,
 		Password: generatePassword(),
 		Args:     args,

--- a/pkg/runplugin/runplugin.go
+++ b/pkg/runplugin/runplugin.go
@@ -36,7 +36,7 @@ func (sch *Scheduler) RunPlugin(image string, args ...string) error {
 		Image:    image,
 		Name:     parts[0],
 		Version:  parts[1],
-		Username: "plugin." + strings.ReplaceAll(base, ":", "-"),
+		Username: "plugin." + base,
 		Password: generatePassword(),
 		Args:     args,
 	}

--- a/pkg/runplugin/runplugin.go
+++ b/pkg/runplugin/runplugin.go
@@ -36,7 +36,7 @@ func (sch *Scheduler) RunPlugin(image string, args ...string) error {
 		Image:    image,
 		Name:     parts[0],
 		Version:  parts[1],
-		Username: strings.ReplaceAll(base, ":", "-"),
+		Username: "plugin." + strings.ReplaceAll(base, ":", "-"),
 		Password: generatePassword(),
 		Args:     args,
 	}


### PR DESCRIPTION
Data sharing service expected plugins' RabbitMQ username to follow a `plugin.name:version` format. I've updated this.

See the wes-data-sharing-service for implementation details: https://github.com/waggle-sensor/wes-data-sharing-service/blob/main/main.py#L34
