### PR TITLE
SAGE-1002 added PULSE_SERVER envvar to runplugin template

### DIFF
--- a/pkg/runplugin/runplugin.go
+++ b/pkg/runplugin/runplugin.go
@@ -145,6 +145,10 @@ func createDeploymentForConfig(config *pluginConfig) *appsv1.Deployment {
 							Args:            config.Args,
 							Env: []apiv1.EnvVar{
 								{
+									Name:  "PULSE_SERVER",
+									Value: "tcp:wes-audio-server:4713",
+								},
+								{
 									Name:  "WAGGLE_PLUGIN_NAME",
 									Value: config.Name + ":" + config.Version,
 								},


### PR DESCRIPTION
I realized the pulseaudio server address was hard coded by default in the audio sampler. This adds it to any plugin deployed with runplugin, so, we can finally have other audio plugins. 🎶 
