### PR TITLE
[SAGE-1007] Provide plugin access to Pod UID using downward API.

### DIFF
--- a/pkg/runplugin/runplugin.go
+++ b/pkg/runplugin/runplugin.go
@@ -181,6 +181,15 @@ func createDeploymentForConfig(config *pluginConfig) *appsv1.Deployment {
 									Name:  "WAGGLE_PLUGIN_PORT",
 									Value: "5672",
 								},
+								// NOTE WAGGLE_APP_ID is used to bind plugin <-> Pod identities.
+								{
+									Name: "WAGGLE_APP_ID",
+									ValueFrom: &apiv1.EnvVarSource{
+										FieldRef: &apiv1.ObjectFieldSelector{
+											FieldPath: "metadata.uid",
+										},
+									},
+								},
 							},
 							EnvFrom: []apiv1.EnvFromSource{
 								{


### PR DESCRIPTION
This addition will provide plugins to access to the Pod UID they are running in. This will allow us to tag measurements with metadata such as where a Pod was scheduled.
