### PR TITLE
Added support for label selector.

### DIFF
--- a/cmd/runplugin/args.go
+++ b/cmd/runplugin/args.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+func parseSelector(s string) (map[string]string, error) {
+	items := map[string]string{}
+
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return items, nil
+	}
+
+	for _, term := range strings.Split(s, ",") {
+		k, v, err := parseSelectorTerm(term)
+		if err != nil {
+			return items, err
+		}
+		items[k] = v
+	}
+
+	return items, nil
+}
+
+func parseSelectorTerm(s string) (string, string, error) {
+	fields := strings.Split(s, "=")
+	if len(fields) != 2 {
+		return "", "", fmt.Errorf("selector terms must have exactly one =")
+	}
+	return strings.TrimSpace(fields[0]), strings.TrimSpace(fields[1]), nil
+}

--- a/cmd/runplugin/args_test.go
+++ b/cmd/runplugin/args_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestParseSelector(t *testing.T) {
+	testcases := []struct {
+		Input string
+		Want  map[string]string
+	}{
+		{"", map[string]string{}},
+		{"resource.gps=true", map[string]string{"resource.gps": "true"}},
+		{"resource.gps=true,resource.bme680=true", map[string]string{"resource.gps": "true", "resource.bme680": "true"}},
+	}
+
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("input %q", tc.Input), func(t *testing.T) {
+			r, err := parseSelector(tc.Input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(r, tc.Want) {
+				t.Fatal(fmt.Errorf("expected empty"))
+			}
+		})
+	}
+}

--- a/cmd/runplugin/main.go
+++ b/cmd/runplugin/main.go
@@ -47,6 +47,7 @@ func main() {
 		job                        string
 		name                       string
 		node                       string
+		selectorStr                string
 		kubeconfig                 string
 		rabbitmqManagementURI      string
 		rabbitmqManagementUsername string
@@ -57,6 +58,7 @@ func main() {
 	flag.StringVar(&job, "job", "sage", "specify plugin job")
 	flag.StringVar(&name, "name", "", "specify plugin name")
 	flag.StringVar(&node, "node", "", "run plugin on node")
+	flag.StringVar(&selectorStr, "selector", "", "selector specifying where plugin can run")
 	flag.StringVar(&kubeconfig, "kubeconfig", getenv("KUBECONFIG", detectDefaultKubeconfig()), "path to the kubeconfig file")
 	flag.StringVar(&rabbitmqManagementURI, "rabbitmq-management-uri", getenv("RABBITMQ_MANAGEMENT_URI", detectDefaultRabbitmqURI()), "rabbitmq management uri")
 	flag.StringVar(&rabbitmqManagementUsername, "rabbitmq-management-username", getenv("RABBITMQ_MANAGEMENT_USERNAME", "admin"), "rabbitmq management username")
@@ -91,6 +93,11 @@ func main() {
 
 	args := flag.Args()
 
+	selector, err := parseSelector(selectorStr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	spec := &runplugin.Spec{
 		Privileged: privileged,
 		Node:       node,
@@ -98,6 +105,7 @@ func main() {
 		Args:       args[1:],
 		Job:        job,
 		Name:       name,
+		Selector:   selector,
 	}
 
 	if err := sch.RunPlugin(spec); err != nil {

--- a/pkg/runplugin/runplugin.go
+++ b/pkg/runplugin/runplugin.go
@@ -25,12 +25,13 @@ type Scheduler struct {
 }
 
 type Spec struct {
-	Image      string   `json:"image"`
-	Args       []string `json:"args"`
-	Privileged bool     `json:"privileged"`
-	Node       string   `json:"node"`
-	Job        string   `json:"job"`
-	Name       string   `json:"name"`
+	Image      string            `json:"image"`
+	Args       []string          `json:"args"`
+	Privileged bool              `json:"privileged"`
+	Node       string            `json:"node"`
+	Job        string            `json:"job"`
+	Name       string            `json:"name"`
+	Selector   map[string]string `json:"selector"`
 }
 
 var validNamePattern = regexp.MustCompile("^[a-z0-9-]+$")
@@ -134,6 +135,9 @@ func nodeSelectorForConfig(config *pluginConfig) map[string]string {
 	if config.Node != "" {
 		vals["k3s.io/hostname"] = config.Node
 	}
+	for k, v := range config.Selector {
+		vals[k] = v
+	}
 	return vals
 }
 
@@ -194,15 +198,6 @@ func createDeploymentForConfig(config *pluginConfig) *appsv1.Deployment {
 									ValueFrom: &apiv1.EnvVarSource{
 										FieldRef: &apiv1.ObjectFieldSelector{
 											FieldPath: "metadata.uid",
-										},
-									},
-								},
-							},
-							EnvFrom: []apiv1.EnvFromSource{
-								{
-									ConfigMapRef: &apiv1.ConfigMapEnvSource{
-										LocalObjectReference: apiv1.LocalObjectReference{
-											Name: "waggle-config",
 										},
 									},
 								},

--- a/pkg/runplugin/runplugin_test.go
+++ b/pkg/runplugin/runplugin_test.go
@@ -16,7 +16,7 @@ func TestGeneratedName(t *testing.T) {
 				Args:  []string{"1", "2", "3"},
 				Image: "waggle/cool-plugin:1.2.3",
 			},
-			want: "cool-plugin-1-2-3-1e463618",
+			want: "cool-plugin-1-2-3-b278f866",
 		},
 		{
 			spec: &Spec{
@@ -24,7 +24,7 @@ func TestGeneratedName(t *testing.T) {
 				Privileged: true,
 				Image:      "waggle/cool-plugin:1.2.3",
 			},
-			want: "cool-plugin-1-2-3-77274c42",
+			want: "cool-plugin-1-2-3-8cca22b6",
 		},
 		{
 			spec: &Spec{
@@ -33,7 +33,7 @@ func TestGeneratedName(t *testing.T) {
 				Node:       "rpi-1",
 				Job:        "weather",
 			},
-			want: "sensor-plugin-0-4-1-cb0c0269",
+			want: "sensor-plugin-0-4-1-1be34680",
 		},
 		{
 			spec: &Spec{
@@ -43,7 +43,7 @@ func TestGeneratedName(t *testing.T) {
 				Node:       "nx-1",
 				Job:        "weather",
 			},
-			want: "sensor-plugin-0-4-1-05d08623",
+			want: "sensor-plugin-0-4-1-171430bb",
 		},
 		{
 			spec: &Spec{


### PR DESCRIPTION
This adds support for the --selector flag to runplugin which allows you to constrain where a plugin runs based on labels instead of just node like we had before.

For example:

```sh
runplugin --selector resource.gps=true waggle/plugin-test-pipeline:0.2.8
```

Multiple labels can be provided as a comma separated list --selector l1=v1,l2=v2,....