### PR TITLE
A quick fix on setting the right ttlseconds for the garbage collector

### DIFF
--- a/pkg/nodescheduler/resourcemanager.go
+++ b/pkg/nodescheduler/resourcemanager.go
@@ -45,7 +45,7 @@ const (
 var (
 	hostPathDirectoryOrCreate       = apiv1.HostPathDirectoryOrCreate
 	backOffLimit              int32 = 0
-	ttlSecondsAfterFinished   int32 = 60
+	ttlSecondsAfterFinished   int32 = 3600
 )
 
 // ResourceManager structs a resource manager talking to a local computing cluster to schedule plugins


### PR DESCRIPTION
The ttlseconds was set to 1 minute, which was too short. This possibly made the `wes-data-sharing-service` crashed, and also made the queue piling up messages.

```
to-validator | classic | D | running | 237,024 | 134,910 | 371,934 | 3.0/s | 775/s | 0.20/s
-- | -- | -- | -- | -- | -- | -- | -- | -- | --


[to-validator](http://localhost:15672/#/queues/%2F/to-validator)
classic	D	running	237,024	134,910	371,934	3.0/s	775/s	0.20/s
```

```bash
2022/02/28 16:06:18 invalid message: no pod with uid 'e4ff06c2-bd53-4e3f-b6c6-f8940b466480'
Traceback (most recent call last):
  File "main.py", line 53, in load_message
    pod = appstate.pods[properties.app_id]
KeyError: 'e4ff06c2-bd53-4e3f-b6c6-f8940b466480'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "main.py", line 138, in on_validator_callback
    msg = load_message(appstate, properties, body)
  File "main.py", line 55, in load_message
    raise InvalidMessageError(f"no pod with uid {key}")
__main__.InvalidMessageError: no pod with uid 'e4ff06c2-bd53-4e3f-b6c6-f8940b466480'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "main.py", line 262, in <module>
    main()
  File "main.py", line 257, in main
    channel.start_consuming()
  File "/usr/local/lib/python3.8/site-packages/pika/adapters/blocking_connection.py", line 1865, in start_consuming
    self._process_data_events(time_limit=None)
  File "/usr/local/lib/python3.8/site-packages/pika/adapters/blocking_connection.py", line 2026, in _process_data_events
    self.connection.process_data_events(time_limit=time_limit)
  File "/usr/local/lib/python3.8/site-packages/pika/adapters/blocking_connection.py", line 833, in process_data_events
    self._dispatch_channel_events()
  File "/usr/local/lib/python3.8/site-packages/pika/adapters/blocking_connection.py", line 567, in _dispatch_channel_events
    impl_channel._get_cookie()._dispatch_events()
  File "/usr/local/lib/python3.8/site-packages/pika/adapters/blocking_connection.py", line 1492, in _dispatch_events
    consumer_info.on_message_callback(self, evt.method,
  File "main.py", line 142, in on_validator_callback
    ch.basic_ack(method.delivery_tag)
  File "/usr/local/lib/python3.8/site-packages/pika/adapters/blocking_connection.py", line 2112, in basic_ack
    self._flush_output()
  File "/usr/local/lib/python3.8/site-packages/pika/adapters/blocking_connection.py", line 1335, in _flush_output
    self._connection._flush_output(lambda: self.is_closed, *waiters)
  File "/usr/local/lib/python3.8/site-packages/pika/adapters/blocking_connection.py", line 523, in _flush_output
    raise self._closed_result.value.error
pika.exceptions.StreamLostError: Stream connection lost: ConnectionResetError(104, 'Connection reset by peer')
kube
```