### PR TITLE
Fixed a bug on handling k3s failure for running plugin

### DIFF
--- a/pkg/nodescheduler/resourcemanager.go
+++ b/pkg/nodescheduler/resourcemanager.go
@@ -812,13 +812,13 @@ func (rm *ResourceManager) LaunchAndWatchPlugin(plugin *datatype.Plugin) {
 	job, err := rm.CreateJob(plugin)
 	if err != nil {
 		logger.Error.Printf("Failed to create Kubernetes Job for %q: %q", plugin.Name, err.Error())
-		rm.Notifier.Notify(datatype.NewEventBuilder(datatype.EventFailure).AddReason(err.Error()).AddPluginMeta(plugin).Build())
+		rm.Notifier.Notify(datatype.NewEventBuilder(datatype.EventPluginStatusFailed).AddReason(err.Error()).AddPluginMeta(plugin).Build())
 		return
 	}
 	_, err = rm.RunPlugin(job)
 	if err != nil {
 		logger.Error.Printf("Failed to run %q: %q", job.Name, err.Error())
-		rm.Notifier.Notify(datatype.NewEventBuilder(datatype.EventFailure).AddReason(err.Error()).AddPluginMeta(plugin).Build())
+		rm.Notifier.Notify(datatype.NewEventBuilder(datatype.EventPluginStatusFailed).AddReason(err.Error()).AddPluginMeta(plugin).Build())
 		return
 	}
 	logger.Info.Printf("Plugin %q deployed", job.Name)
@@ -829,7 +829,7 @@ func (rm *ResourceManager) LaunchAndWatchPlugin(plugin *datatype.Plugin) {
 		logger.Error.Printf("Failed to watch %q. Abort the execution", job.Name)
 		rm.TerminateJob(job.Name)
 		// rm.UpdateReservation(false)
-		rm.Notifier.Notify(datatype.NewEventBuilder(datatype.EventFailure).AddReason(err.Error()).AddK3SJobMeta(job).AddPluginMeta(plugin).Build())
+		rm.Notifier.Notify(datatype.NewEventBuilder(datatype.EventPluginStatusFailed).AddReason(err.Error()).AddK3SJobMeta(job).AddPluginMeta(plugin).Build())
 		return
 	}
 	chanEvent := watcher.ResultChan()
@@ -861,13 +861,13 @@ func (rm *ResourceManager) LaunchAndWatchPlugin(plugin *datatype.Plugin) {
 		case watch.Deleted:
 			logger.Debug.Printf("Plugin got deleted. Returning resource and notify")
 			// rm.UpdateReservation(false)
-			rm.Notifier.Notify(datatype.NewEventBuilder(datatype.EventFailure).AddReason("Plugin deleted").AddK3SJobMeta(job).AddPluginMeta(plugin).Build())
+			rm.Notifier.Notify(datatype.NewEventBuilder(datatype.EventPluginStatusFailed).AddReason("Plugin deleted").AddK3SJobMeta(job).AddPluginMeta(plugin).Build())
 			return
 		case watch.Error:
 			logger.Debug.Printf("Error on watcher. Returning resource and notify")
 			rm.TerminateJob(job.Name)
 			// rm.UpdateReservation(false)
-			rm.Notifier.Notify(datatype.NewEventBuilder(datatype.EventFailure).AddReason("Error on watcher").AddK3SJobMeta(job).AddPluginMeta(plugin).Build())
+			rm.Notifier.Notify(datatype.NewEventBuilder(datatype.EventPluginStatusFailed).AddReason("Error on watcher").AddK3SJobMeta(job).AddPluginMeta(plugin).Build())
 			return
 		}
 	}


### PR DESCRIPTION
When the following error occurred, the node scheduler didn't handle it properly, resulting in leaving the plugin status Running forever (and it was not running due to the error). To properly handle this kind of error, we treat it as "plugin status failure" instead of general failure. This way, the scheduler will attempt to schedule it whenever needed.

```bash
ERROR: 2022/05/18 04:01:00 resourcemanager.go:844: Failed to run "sound-event-detection-1652846450": "Post \"https://10.43.0.1:443/apis/batch/v1/namespaces/ses/jobs\": context deadline exceeded"
```